### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ tls_client.write "hallo\n"
 tls_client.close
 ```
 
-Client Connections don't have a configureable config at the moment
+Client Connections don't have a configurable config at the moment
 
 The following Errors can be thrown:
 ```ruby


### PR DESCRIPTION
@Asmod4n, I've corrected a typographical error in the documentation of the [mruby-tls](https://github.com/Asmod4n/mruby-tls) project. Specifically, I've changed configureable to configurable. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
